### PR TITLE
Highlight overlapping phrase in devil page

### DIFF
--- a/assets/styles/devil.css
+++ b/assets/styles/devil.css
@@ -8,6 +8,10 @@ body {
   text-shadow: 0 0 5px #f00, 0 0 10px #000;
 }
 
+.overlap {
+  color: #fff;
+}
+
 @keyframes flickerText {
   0%   { opacity: 1; }
   5%   { opacity: 0.4; }

--- a/devil.html
+++ b/devil.html
@@ -7,15 +7,6 @@
   <title>If I Told You I Was the Devil</title>
   <link rel="stylesheet" href="assets/styles/devil.css" />
 </head>
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="If I Told You I Was the Devil | tw¡st3d_¡nk" />
-  <title>If I Told You I Was the Devil</title>
-  <link rel="stylesheet" href="assets/styles/devil.css" />
-</head>
 
 <body style="background: url('assets/images/devil_bg.jpg') no-repeat center center fixed; background-size: cover; color: #f00; font-family: monospace;">
   <!-- Audio layers -->
@@ -31,8 +22,8 @@
   <main id="content">
     <h1 class="glitch-text">If I Told You I Was the Devil</h1>
     <p>
-      Would you believe me?<br />
-      Would you see the horns behind my smile,<br />
+        <span class="overlap">Would you</span> believe me?<br />
+        <span class="overlap">Would you</span> see the horns behind my smile,<br />
       or just the charm that keeps you guessing who's really in control?
     </p>
     <p>


### PR DESCRIPTION
## Summary
- remove duplicated document header and structure in `devil.html`
- highlight repeated "Would you" phrases with a new `.overlap` style

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c7a0a20ff88325be161a7f352e8f77